### PR TITLE
support loading pointer, structure, array type

### DIFF
--- a/cle/backends/elf/compilation_unit.py
+++ b/cle/backends/elf/compilation_unit.py
@@ -11,7 +11,7 @@ class CompilationUnit:
     See http://dwarfstd.org/doc/DWARF5.pdf page 60
     """
 
-    def __init__(self, name, comp_dir, low_pc, high_pc, language, type_dict):
+    def __init__(self, name, comp_dir, low_pc, high_pc, language):
         self.name = name
         self.comp_dir = comp_dir
         self.file_path = os.path.join(self.comp_dir, self.name)
@@ -20,7 +20,6 @@ class CompilationUnit:
         self.language = language
         self.functions: Dict[int, Subprogram] = {}
         self.global_variables: List[Variable] = []
-        self.type_dict: Dict[int, VariableType] = type_dict
 
     @property
     def global_vars(self):

--- a/cle/backends/elf/compilation_unit.py
+++ b/cle/backends/elf/compilation_unit.py
@@ -11,7 +11,7 @@ class CompilationUnit:
     See http://dwarfstd.org/doc/DWARF5.pdf page 60
     """
 
-    def __init__(self, name, comp_dir, low_pc, high_pc, language):
+    def __init__(self, name, comp_dir, low_pc, high_pc, language, type_dict):
         self.name = name
         self.comp_dir = comp_dir
         self.file_path = os.path.join(self.comp_dir, self.name)
@@ -20,6 +20,7 @@ class CompilationUnit:
         self.language = language
         self.functions: Dict[int, Subprogram] = {}
         self.global_variables: List[Variable] = []
+        self.type_dict: Dict[int, VariableType] = type_dict
 
     @property
     def global_vars(self):

--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -675,7 +675,7 @@ class ELF(MetaELF):
             try:
                 for die in cu.iter_DIEs():
                     if VariableType.supported_die(die):
-                        var_type = VariableType.read_from_die(die)
+                        var_type = VariableType.read_from_die(die, self)
                         if var_type is not None:
                             type_list[die.offset] = var_type
             except KeyError:
@@ -701,7 +701,7 @@ class ELF(MetaELF):
             die_comp_dir = die_comp_dir.value.decode('utf-8')
             die_lang = describe_attr_value(die_lang, top_die, top_die.offset)
 
-            cu_ = CompilationUnit(die_name, die_comp_dir, die_low_pc, die_high_pc,die_lang, type_list)
+            cu_ = CompilationUnit(die_name, die_comp_dir, die_low_pc, die_high_pc,die_lang)
             compilation_units.append(cu_)
 
             for die_child in cu.iter_DIE_children(top_die):
@@ -716,6 +716,7 @@ class ELF(MetaELF):
                     if sub_prog is not None:
                         cu_.functions[sub_prog.low_pc] = sub_prog
 
+        self.type_list = type_list
         self.compilation_units = compilation_units
 
     def _load_die_lex_block(self, die: DIE, expr_parser, type_list, cu, file_path, super_block) -> LexicalBlock:

--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -674,7 +674,7 @@ class ELF(MetaELF):
             # scan the whole die tree for DW_TAG_base_type
             try:
                 for die in cu.iter_DIEs():
-                    if die.tag == "DW_TAG_base_type":
+                    if VariableType.supported_die(die):
                         var_type = VariableType.read_from_die(die)
                         if var_type is not None:
                             type_list[die.offset] = var_type
@@ -701,7 +701,7 @@ class ELF(MetaELF):
             die_comp_dir = die_comp_dir.value.decode('utf-8')
             die_lang = describe_attr_value(die_lang, top_die, top_die.offset)
 
-            cu_ = CompilationUnit(die_name, die_comp_dir, die_low_pc, die_high_pc,die_lang)
+            cu_ = CompilationUnit(die_name, die_comp_dir, die_low_pc, die_high_pc,die_lang, type_list)
             compilation_units.append(cu_)
 
             for die_child in cu.iter_DIE_children(top_die):

--- a/cle/backends/elf/variable_type.py
+++ b/cle/backends/elf/variable_type.py
@@ -171,7 +171,7 @@ class StructType(VariableType):
 class MemberType:
     """
     Entry class for DWARF_TAG_member_type.
-    Note that this is not a real type, it is just a named member of a stuct or union.
+    Note that this is not a real type, it is just a named member inside a stuct or union.
     Use the property `type` of a member to get the proper variable type.
 
     :param name:          name of the member

--- a/cle/backends/elf/variable_type.py
+++ b/cle/backends/elf/variable_type.py
@@ -3,7 +3,14 @@ from elftools.dwarf.die import DIE
 
 class VariableType:
     """
-    DW_TAG_base_type for DWARF
+    Entry class for DWARF_TAG_..._type
+
+    :param name:            name of the type
+    :param byte_size:       amount of bytes the type take in memory
+
+    :ivar name:             name of the type
+    :type name:             str
+    :ivar byte_size:        amount of bytes the type take in memory
     """
     def __init__(self, name: str, byte_size:int):
         self.name = name
@@ -11,6 +18,77 @@ class VariableType:
 
     @staticmethod
     def read_from_die(die: DIE):
+        """
+        entry method to read a DW_TAG_..._type
+        """
+        if die.tag == 'DW_TAG_base_type':
+            return VariableBaseType.read_from_die(die)
+        elif die.tag == 'DW_TAG_pointer_type':
+            return VariablePointerType.read_from_die(die)
+        elif die.tag == 'DW_TAG_structure_type':
+            return VariableStructureType.read_from_die(die)
+        elif die.tag == 'DW_TAG_member':
+            return VariableMemberType.read_from_die(die)
+        elif die.tag == 'DW_TAG_array_type':
+            return VariableArrayType.read_from_die(die)
+        return None
+
+    @staticmethod
+    def supported_die(die: DIE) -> bool:
+        return die.tag == 'DW_TAG_base_type'\
+            or die.tag == 'DW_TAG_pointer_type'\
+            or die.tag == 'DW_TAG_structure_type'\
+            or die.tag == 'DW_TAG_member'\
+            or die.tag == 'DW_TAG_array_type'
+
+
+class VariablePointerType(VariableType):
+    """
+    Entry class for DWARF_TAG_pointer_type. It is inherited from VariableType
+
+    :param byte_size:       amount of bytes the type take in memory
+    :param pointee_offset:  offset in the compilation_unit of the pointee type
+
+    :ivar pointee_offset:   offset in the compilation_unit of the pointee type
+    """
+
+    def __init__(self, byte_size: int, pointee_offset: int):
+        super().__init__('pointer', byte_size)
+        self.pointee_offset = pointee_offset
+
+    @staticmethod
+    def read_from_die(die: DIE):
+        """
+        read an entry of DW_TAG_pointer_type. return None when there is no
+        byte_size or type attribute.
+        """
+        byte_size = die.attributes.get('DW_AT_byte_size', None)
+
+        if byte_size is None:
+            return None
+
+        dw_at_type = die.attributes.get('DW_AT_type', None)
+        if dw_at_type is None:
+            return None
+
+        return VariablePointerType(byte_size.value, dw_at_type.value)
+
+
+class VariableBaseType(VariableType):
+    """
+    Entry class for DWARF_TAG_base_type. It is inherited from VariableType
+    """
+
+    def __init__(self, name: str, byte_size: int):
+        super().__init__(name, byte_size)
+
+    @staticmethod
+    def read_from_die(die: DIE):
+        """
+        read an entry of DW_TAG_base_type. return None when there is no
+        byte_size attribute.
+        """
+
         dw_at_name = die.attributes.get("DW_AT_name", None)
         byte_size = die.attributes.get("DW_AT_byte_size", None)
         if byte_size is None:
@@ -18,4 +96,110 @@ class VariableType:
         return VariableType(
             name = dw_at_name.value.decode() if dw_at_name is not None else "unknown",
             byte_size = byte_size.value
+        )
+
+
+class VariableStructureType(VariableType):
+    """
+    Entry class for DWARF_TAG_structure_type. It is inherited from VariableType
+
+    :param name:            name of the type
+    :param byte_size:       amount of bytes the type take in memory
+    :param member_offset:   offsets in the compilation_unit of the member type
+
+    :ivar member_offset:    offsets in the compilation_unit of the member type
+    :type member_offset:    List[int]
+    """
+
+    def __init__(self, name: str, byte_size: int, member_offsets):
+        super().__init__(name, byte_size)
+        self.member_offsets = member_offsets
+
+    @staticmethod
+    def read_from_die(die: DIE):
+        """
+        read an entry of DW_TAG_structure_type. return None when there is no
+        byte_size attribute.
+        """
+
+        dw_at_name = die.attributes.get("DW_AT_name", None)
+        byte_size = die.attributes.get('DW_AT_byte_size', None)
+
+        if byte_size is None:
+            return None
+
+        member_offsets = []
+        for die_children in die.iter_children():
+            if VariableType.supported_die(die_children):
+                member_offset = die_children.offset
+                member_offsets.append(member_offset)
+
+        return VariableStructureType(
+            dw_at_name.value.decode() if dw_at_name is not None else "unknown",
+            byte_size.value,
+            member_offsets
+        )
+
+
+class VariableMemberType(VariableType):
+    """
+    Entry class for DWARF_TAG_member_type. It is inherited from VariableType
+
+    :param name:            name of the member type
+    :param reference_offset:  offset in the compilation_unit of the reference type
+
+    :ivar reference_offset:   offset in the compilation_unit of the reference type
+    """
+
+    def __init__(self, name: str, reference_offset):
+        super().__init__(name, None)
+        self.reference_offset = reference_offset
+
+    @staticmethod
+    def read_from_die(die: DIE):
+        """
+        read an entry of DW_TAG_member_type. return None when there is no
+        type attribute.
+        """
+
+        dw_at_name = die.attributes.get('DW_AT_name', None)
+
+        dw_at_type = die.attributes.get('DW_AT_type', None)
+        if dw_at_type is None:
+            return None
+        return VariableMemberType(
+            dw_at_name.value.decode() if dw_at_name is not None else 'unknown',
+            dw_at_type.value
+        )
+
+
+class VariableArrayType(VariableType):
+    """
+    Entry class for DWARF_TAG_array_type. It is inherited from VariableType
+
+    :param byte_size:       amount of bytes the type take in memory
+    :param reference_offset:  offset in the compilation_unit of the reference type
+
+    :ivar reference_offset:   offset in the compilation_unit of the reference type
+    """
+
+    def __init__(self, byte_size, reference_offset):
+        super().__init__("array", byte_size)
+        self.reference_offset = reference_offset
+
+    @staticmethod
+    def read_from_die(die: DIE):
+        """
+        read an entry of DW_TAG_array_type. return None when there is no
+        type attribute.
+        """
+
+        dw_byte_size = die.attributes.get("DW_AT_byte_size", None)
+
+        dw_at_type = die.attributes.get("DW_AT_type", None)
+        if dw_at_type is None:
+            return None
+        return VariableArrayType(
+            dw_byte_size.value if dw_byte_size is not None else None,
+            dw_at_type.value
         )

--- a/cle/backends/elf/variable_type.py
+++ b/cle/backends/elf/variable_type.py
@@ -7,30 +7,32 @@ class VariableType:
 
     :param name:            name of the type
     :param byte_size:       amount of bytes the type take in memory
+    :param elf_object:      elf object to reference to (useful for pointer,...)
 
     :ivar name:             name of the type
     :type name:             str
     :ivar byte_size:        amount of bytes the type take in memory
     """
-    def __init__(self, name: str, byte_size:int):
+    def __init__(self, name: str, byte_size:int, elf_object):
         self.name = name
         self.byte_size = byte_size
+        self._elf_object = elf_object
 
     @staticmethod
-    def read_from_die(die: DIE):
+    def read_from_die(die: DIE, elf_object):
         """
         entry method to read a DW_TAG_..._type
         """
         if die.tag == 'DW_TAG_base_type':
-            return VariableBaseType.read_from_die(die)
+            return VariableBaseType.read_from_die(die, elf_object)
         elif die.tag == 'DW_TAG_pointer_type':
-            return VariablePointerType.read_from_die(die)
+            return VariablePointerType.read_from_die(die, elf_object)
         elif die.tag == 'DW_TAG_structure_type':
-            return VariableStructureType.read_from_die(die)
+            return VariableStructureType.read_from_die(die, elf_object)
         elif die.tag == 'DW_TAG_member':
-            return VariableMemberType.read_from_die(die)
+            return VariableMemberType.read_from_die(die, elf_object)
         elif die.tag == 'DW_TAG_array_type':
-            return VariableArrayType.read_from_die(die)
+            return VariableArrayType.read_from_die(die, elf_object)
         return None
 
     @staticmethod
@@ -47,17 +49,18 @@ class VariablePointerType(VariableType):
     Entry class for DWARF_TAG_pointer_type. It is inherited from VariableType
 
     :param byte_size:       amount of bytes the type take in memory
+    :param elf_object:      elf object to reference to (useful for pointer,...)
     :param pointee_offset:  offset in the compilation_unit of the pointee type
 
     :ivar pointee_offset:   offset in the compilation_unit of the pointee type
     """
 
-    def __init__(self, byte_size: int, pointee_offset: int):
-        super().__init__('pointer', byte_size)
+    def __init__(self, byte_size: int, elf_object, pointee_offset: int):
+        super().__init__('pointer', byte_size, elf_object)
         self.pointee_offset = pointee_offset
 
     @staticmethod
-    def read_from_die(die: DIE):
+    def read_from_die(die: DIE, elf_object):
         """
         read an entry of DW_TAG_pointer_type. return None when there is no
         byte_size or type attribute.
@@ -71,19 +74,28 @@ class VariablePointerType(VariableType):
         if dw_at_type is None:
             return None
 
-        return VariablePointerType(byte_size.value, dw_at_type.value)
+        return VariablePointerType(byte_size.value, elf_object, dw_at_type.value)
 
+    @property
+    def pointee(self):
+        """
+        attribute to get the pointee type. Return None if the type is not loaded
+        """
+        type_list = self._elf_object.type_list
+        if self.pointee_offset in type_list.keys():
+            return type_list[self.pointee_offset]
+        return None
 
 class VariableBaseType(VariableType):
     """
     Entry class for DWARF_TAG_base_type. It is inherited from VariableType
     """
 
-    def __init__(self, name: str, byte_size: int):
-        super().__init__(name, byte_size)
+    def __init__(self, name: str, byte_size: int, elf_object):
+        super().__init__(name, byte_size, elf_object)
 
     @staticmethod
-    def read_from_die(die: DIE):
+    def read_from_die(die: DIE, elf_object):
         """
         read an entry of DW_TAG_base_type. return None when there is no
         byte_size attribute.
@@ -94,8 +106,9 @@ class VariableBaseType(VariableType):
         if byte_size is None:
             return None
         return VariableType(
-            name = dw_at_name.value.decode() if dw_at_name is not None else "unknown",
-            byte_size = byte_size.value
+            dw_at_name.value.decode() if dw_at_name is not None else "unknown",
+            byte_size.value,
+            elf_object
         )
 
 
@@ -105,18 +118,19 @@ class VariableStructureType(VariableType):
 
     :param name:            name of the type
     :param byte_size:       amount of bytes the type take in memory
+    :param elf_object:      elf object to reference to (useful for pointer,...)
     :param member_offset:   offsets in the compilation_unit of the member type
 
     :ivar member_offset:    offsets in the compilation_unit of the member type
     :type member_offset:    List[int]
     """
 
-    def __init__(self, name: str, byte_size: int, member_offsets):
-        super().__init__(name, byte_size)
+    def __init__(self, name: str, byte_size: int, elf_object, member_offsets):
+        super().__init__(name, byte_size, elf_object)
         self.member_offsets = member_offsets
 
     @staticmethod
-    def read_from_die(die: DIE):
+    def read_from_die(die: DIE, elf_object):
         """
         read an entry of DW_TAG_structure_type. return None when there is no
         byte_size attribute.
@@ -137,8 +151,25 @@ class VariableStructureType(VariableType):
         return VariableStructureType(
             dw_at_name.value.decode() if dw_at_name is not None else "unknown",
             byte_size.value,
+            elf_object,
             member_offsets
         )
+
+    @property
+    def members(self):
+        """
+        attribute to get a list of all members type.
+        Member entry is loaded correspond to the order defined in source code
+        Member could be None if the type is not loaded (not supported)
+        """
+        members = []
+        type_list = self._elf_object.type_list
+        for member_offset in self.member_offsets:
+            if member_offset in type_list.keys():
+                members.append(type_list[member_offset].reference_type)
+            else:
+                members.append(None)
+        return members
 
 
 class VariableMemberType(VariableType):
@@ -146,17 +177,18 @@ class VariableMemberType(VariableType):
     Entry class for DWARF_TAG_member_type. It is inherited from VariableType
 
     :param name:            name of the member type
+    :param elf_object:      elf object to reference to (useful for pointer,...)
     :param reference_offset:  offset in the compilation_unit of the reference type
 
     :ivar reference_offset:   offset in the compilation_unit of the reference type
     """
 
-    def __init__(self, name: str, reference_offset):
-        super().__init__(name, None)
+    def __init__(self, name: str, elf_object, reference_offset):
+        super().__init__(name, None, elf_object)
         self.reference_offset = reference_offset
 
     @staticmethod
-    def read_from_die(die: DIE):
+    def read_from_die(die: DIE, elf_object):
         """
         read an entry of DW_TAG_member_type. return None when there is no
         type attribute.
@@ -169,26 +201,38 @@ class VariableMemberType(VariableType):
             return None
         return VariableMemberType(
             dw_at_name.value.decode() if dw_at_name is not None else 'unknown',
+            elf_object,
             dw_at_type.value
         )
+    @property
+    def reference_type(self):
+        """
+        attribute to get the reference type. Return None if the type is not loaded
+        """
+
+        type_list = self._elf_object.type_list
+        if self.reference_offset in type_list.keys():
+            return type_list[self.reference_offset]
+        return None
 
 
-class VariableArrayType(VariableType):
+class VariableArrayType(VariablePointerType):
     """
     Entry class for DWARF_TAG_array_type. It is inherited from VariableType
 
     :param byte_size:       amount of bytes the type take in memory
+    :param elf_object:      elf object to reference to (useful for pointer,...)
     :param reference_offset:  offset in the compilation_unit of the reference type
 
     :ivar reference_offset:   offset in the compilation_unit of the reference type
     """
 
-    def __init__(self, byte_size, reference_offset):
-        super().__init__("array", byte_size)
-        self.reference_offset = reference_offset
+    def __init__(self, byte_size, elf_object, pointee_offset):
+        super().__init__(byte_size, elf_object, pointee_offset)
+        self.name = "array"
 
     @staticmethod
-    def read_from_die(die: DIE):
+    def read_from_die(die: DIE, elf_object):
         """
         read an entry of DW_TAG_array_type. return None when there is no
         type attribute.
@@ -201,5 +245,6 @@ class VariableArrayType(VariableType):
             return None
         return VariableArrayType(
             dw_byte_size.value if dw_byte_size is not None else None,
+            elf_object,
             dw_at_type.value
         )


### PR DESCRIPTION
this partially solve [#10](https://github.com/lks9/angr/issues/10#issue-1418408939) to support pointer, structure, array type. I also added an attribute `Compilation_Unit.type_dict` which is a dictionary that map the offset in DWARF to corresponding type object.